### PR TITLE
Enable issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Palm Core Team
+    url: data-analytics-team@palmetto.com
+    about: Please report security vulnerabilities to this email address, not in public issues.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [ ] All new and existing tests pass locally (`palm test`)
- [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.
Feature being enabled with this config file detailed here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
I noticed that opening a new issue currently opens a blank issue, even though we have bug fix and new feature suggestion issue templates in the repo. This feature should enable the template chooser, so contributors who want to open an issue will be able to select between our two issue types.

## Does this close any currently open issues?
…

## Any other comments?
…

## Where has this been tested?

**Operating System:** …

**Platform:** …

**Target Platform:** …
