### PR TITLE
Remove the - from the package name because palm-cli is taken on pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ DS_Store
 
 docs/_build
 
-palm.egg-info
+*.egg-info
 dist
 build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Palm CLI Changelog
 
+## 2.0.1
+
+> 11/10/2021
+
+Updates to configuration and package name due to an unexpected naming conflict in
+pypi
+
 ## 2.0.0
 
-> Unreleased
+> 11/10/2021
 
 This major version marks our first open-source release, and thus the first version
 with a changelog entry!

--- a/README.md
+++ b/README.md
@@ -6,19 +6,31 @@ _Palm_ is a universal CLI developed to improve the life and work of data profess
 
 ### Installing Palm
 
+```
+pip install palmcli
+```
+
+*note for mac users*: if you get this warning:
+```
+  WARNING: The script palm is installed in '/Users/yourname/Library/Python/3.8/bin' which is not on PATH.
+  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
+  ```
+you will need to add `'/Users/yourname/Library/Python/3.8/bin'` to your path for `palm` to work. 
+
+you can do that with this command:
+```
+echo "\nexport PATH=$PATH:/Users/yourname/Library/Python/3.8/bin\n" >> ~/.zprofile
+```
+
+#### Requirements
+
 1. You will need [Docker](https://docs.docker.com/get-docker/)
    You can check to see if you already have it with `docker --version`
 
 2. You will need [Python3](https://www.python.org/downloads/) 
    You can check to see if you already have it with `python3 --version`
 
-**Fastest Method: Using Pip**
-Run this from the command line:
-```
-python3 -m pip uninstall palm || true
-python3 -m pip install git+https://github.com/palmetto/palm-cli.git
-```
-It will ask you to log into Github, and then `palm` will be installed
+#### Developing palm
 
 **If you have the repo on your computer** 
 This will install whatever version you have checked out at the moment.
@@ -32,16 +44,4 @@ python3 -m pip install .
 You can verify the install with
 ```
 palm --help
-```
-
-*note for mac users*: if you get this warning:
-```
-  WARNING: The script palm is installed in '/Users/yourname/Library/Python/3.8/bin' which is not on PATH.
-  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
-  ```
-you will need to add `'/Users/yourname/Library/Python/3.8/bin'` to your path for `palm` to work. 
-
-you can do that with this command:
-```
-echo "\nexport PATH=$PATH:/Users/yourname/Library/Python/3.8/bin\n" >> ~/.zprofile
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2021, Palmetto Data Team'
 author = 'Palmetto Data Team'
 
 # The full version, including alpha/beta/rc tags
-release = '2.0.0'
+release = '2.0.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -45,7 +45,7 @@ Installation
 
 Install Palm CLI via pip:
 
-``pip install palm-cli``
+``pip install palmcli``
 
 For development installations, you may also install palm from source by cloning
 the codebase and running ``python3 -m pip install .``

--- a/palm/cli.py
+++ b/palm/cli.py
@@ -80,7 +80,7 @@ class PalmCLI(click.MultiCommand):
 
 def get_version():
     try:
-        version = pkg_resources.require("palm")[0].version
+        version = pkg_resources.require("palmcli")[0].version
     except pkg_resources.DistributionNotFound:
         version = 'unknown'
     return version

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ this_directory = Path(__file__).parent
 long_description = Path(this_directory, 'README.md').read_text()
 
 setup(
-    name='palm-cli',
+    name='palmcli',
     version='2.0.0',  # Don't forget to bump the version in docs/source/conf.py too!
     description='Palm CLI',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ long_description = Path(this_directory, 'README.md').read_text()
 
 setup(
     name='palmcli',
-    version='2.0.0',  # Don't forget to bump the version in docs/source/conf.py too!
+    version='2.0.1',  # Don't forget to bump the version in docs/source/conf.py too!
     description='Palm CLI',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

palm-cli is taken on pypi, even though it doesn't exist... palmcli is not taken. Remove the `-` so we can publish!
