### PR TITLE
Improve boilerplate commands when scaffolding

### DIFF
--- a/palm/plugins/core/templates/command/new_cmd.tpl.py
+++ b/palm/plugins/core/templates/command/new_cmd.tpl.py
@@ -2,7 +2,12 @@ import click
 
 
 @click.command('{{command}}')
-@click.pass_context
-def cli(ctx):
+@click.pass_obj
+def cli(environment):
     """{{command}}"""
-    click.echo("{{command}} command running!")
+    click.echo("palm executing {{command}}")
+    command = f"echo '{{command}} running!'"
+    # Run your command in docker:
+    # environment.run_in_docker(command)
+    # Or on the host:
+    # environment.run_on_host(command)

--- a/palm/plugins/core/templates/command_group/new_cmd_group.tpl.py
+++ b/palm/plugins/core/templates/command_group/new_cmd_group.tpl.py
@@ -9,9 +9,14 @@ def cli():
 
 {% for command in commands %}
 @cli.command()
-@click.pass_context
-def {{command}}(ctx):
+@click.pass_obj
+def {{command}}(environment):
     """{{command}}"""
     click.echo("{{command}} command running!")
+    command = "echo {{command}} running" 
+    # Run your command in docker:
+    # environment.run_in_docker(command)
+    # Or on the host:
+    # environment.run_on_host(command)
 
 {% endfor %}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -90,7 +90,7 @@ def test_scaffold_new_command_group(use_palm_dir):
     target_path = Path('.palm', 'cmd_groupname.py')
     assert target_path.exists()
     assert "@click.group()" in target_path.read_text()
-    assert "def test(ctx):" in target_path.read_text()
+    assert "def test(environment):" in target_path.read_text()
 
 
 def test_scaffold_config(use_palm_dir):


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

The `@click.pass_obj` decorator passes `ctx.obj` to the command, by naming this arg `environment` we create a much more obvious interface to `Environment` instance methods.
Also added some commented out examples for run_in_docker and run_on_host, which should improve developer experience for folks that are new to palm.

## Does this close any currently open issues?
…

## Any other comments?
…

## Where has this been tested?

**Operating System:** Mac OS
