### PR TITLE
Pin version of black for dev/CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,3 +37,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: '--check --diff --skip-string-normalization --exclude="\.tpl\.py"'
+          version: '21.12b0'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
 pytest >= 6.2, < 6.3
-black >= 19.10b0, < 20.0
+black == 21.12b0


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Locally I was seeing some linting errors, on CI linting was passing. This was due to a version mismatch of `black` between the CI and local dev-requirements. By explicitly pinning the version of black we ensure there are no version differences between local and CI
