### PR TITLE
[FEATURE] palm override command

### DIFF
--- a/palm/plugins/core/commands/cmd_override.py
+++ b/palm/plugins/core/commands/cmd_override.py
@@ -2,6 +2,7 @@ import click
 import shutil
 from pathlib import Path
 
+
 @click.command('override')
 @click.option('--name', multiple=False, required=True, help='Name of the command')
 @click.pass_obj
@@ -17,8 +18,11 @@ def cli(environment, name: str):
         return
 
     if not target_path.parent.exists():
-        click.secho("palm is not initialized in this project, please run 'palm init' first", fg='red')
+        click.secho(
+            "palm is not initialized in this project, please run 'palm init' first",
+            fg='red',
+        )
         return
-    
+
     shutil.copy(origin_path, target_path)
     click.secho(f"{name} command overridden to {target_path}", fg='green')

--- a/palm/plugins/core/commands/cmd_override.py
+++ b/palm/plugins/core/commands/cmd_override.py
@@ -1,0 +1,24 @@
+import click
+import shutil
+from pathlib import Path
+
+@click.command('override')
+@click.option('--name', multiple=False, required=True, help='Name of the command')
+@click.pass_obj
+def cli(environment, name: str):
+    """Override a command in the current project"""
+    spec = environment.plugin_manager.command_spec(name)
+    origin_path = Path(spec.origin)
+    file_name = origin_path.name
+    target_path = Path(environment.palm.project_root, '.palm', file_name)
+
+    if target_path.exists():
+        click.secho('Command already exists in project, skipping', fg='red')
+        return
+
+    if not target_path.parent.exists():
+        click.secho("palm is not initialized in this project, please run 'palm init' first", fg='red')
+        return
+    
+    shutil.copy(origin_path, target_path)
+    click.secho(f"{name} command overridden to {target_path}", fg='green')


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Adds a new command that allows users to override an existing command into the current project.

Uses plugin manager to allow overriding a command from a plugin, this also allows commands overridden in plugins to be overridden in the application e.g. `palm shell` is part of the core palm commands, but is overridden in `palm-dbt`, running `palm override --name shell` in a project which uses palm-dbt will pull the command from the plugin into the project!

## Does this close any currently open issues?
DATA-72 (Palmetto internal)

