### PR TITLE
Allow commands to be run in Docker without bin/bash -c

### DIFF
--- a/palm/environment.py
+++ b/palm/environment.py
@@ -16,7 +16,7 @@ class Environment:
         self.plugin_manager = plugin_manager
 
     def run_in_docker(
-        self, cmd: str, env_vars: Optional[dict] = {}
+        self, cmd: str, env_vars: Optional[dict] = {}, no_bin_bash: Optional[bool] = False
     ) -> Tuple[bool, str]:
         """Shells out and runs the cmd in docker
 
@@ -29,7 +29,10 @@ class Environment:
         docker_cmd = ['docker-compose run --service-ports --rm']
         docker_cmd.extend(self._build_env_vars(env_vars))
         docker_cmd.append(self.palm.image_name)
-        docker_cmd.append(f'/bin/bash -c "{cmd}" ')
+        if no_bin_bash:
+            docker_cmd.append(cmd)
+        else:
+            docker_cmd.append(f'/bin/bash -c "{cmd}" ')
 
         ex_code, _, _ = run_on_host(' '.join(docker_cmd))
         if ex_code == 0:

--- a/palm/environment.py
+++ b/palm/environment.py
@@ -16,7 +16,10 @@ class Environment:
         self.plugin_manager = plugin_manager
 
     def run_in_docker(
-        self, cmd: str, env_vars: Optional[dict] = {}, no_bin_bash: Optional[bool] = False
+        self,
+        cmd: str,
+        env_vars: Optional[dict] = {},
+        no_bin_bash: Optional[bool] = False,
     ) -> Tuple[bool, str]:
         """Shells out and runs the cmd in docker
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

In the event we want to run a command in a container that uses a fixed entrypoint, `bin/bash -c` causes palm to not be usable. By making this an optional part of the command string passed to docker, users can program their palm commands with `no_bin_bash=True`, allowing them to interact with their container without running into this issue.

## Does this close any currently open issues?
N/A

## Any other comments?
This enables us to run igluctl with palm (internal PR coming soon!)

## Where has this been tested?

**Operating System:** MacOs