### PR TITLE
Resolve security issue with checking for github packages

### DIFF
--- a/palm/plugins/base.py
+++ b/palm/plugins/base.py
@@ -1,6 +1,7 @@
 import importlib
 from typing import List, Optional, Tuple
 from pathlib import Path
+from urllib.parse import urlparse
 from palm.utils import is_cmd_file, cmd_name_from_file, run_on_host
 
 
@@ -71,7 +72,9 @@ class BasePlugin:
         """
         if self.package_location is None:
             return (False, 'This plugin does not support upgrading via palm')
-        if 'github.com' in self.package_location:
+
+        package_url = urlparse(self.package_location)
+        if package_url.netloc == 'github.com':
             install_url = f'git+{self.package_location}'
         else:  # This should be a pypi package name
             install_url = self.package_location


### PR DESCRIPTION
- use urlparse from urllib.parse to check the host, rather than chekcing for github.com anywhere in the package_location

<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

Resolve a high severity security issue.

## Does this close any currently open issues?

Resolves security issue detected by CodeQL here: https://github.com/palmetto/palm-cli/security/code-scanning/1

## Any other comments?

CodeQL is sweet!

