### PR TITLE
[BUGFIX] Bad assignment of bool into dict variable

### DIFF
--- a/palm/plugins/base_plugin_config.py
+++ b/palm/plugins/base_plugin_config.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-import click
 from pathlib import Path
+
+import click
 import yaml
 from pydantic import BaseModel, ValidationError
 
@@ -18,8 +19,7 @@ class BasePluginConfig(ABC):
         """Setter for plugin config
 
         This method should be implemented by the plugin to set the config
-        for the plugin. It should return True if the config was set successfully,
-        and False if it was not.
+        for the plugin. It should return the dict for the config that was set.
 
         Returns:
             dict: The config that was set
@@ -72,10 +72,10 @@ class BasePluginConfig(ABC):
 
     def _read(self) -> dict:
         palm_config = yaml.load(self.config_path.read_text(), Loader=yaml.FullLoader)
-        plugin_config = palm_config.get('plugin_config', {}).get(self.plugin_name, {})
+        plugin_config = palm_config.get("plugin_config", {}).get(self.plugin_name, {})
 
         if not plugin_config:
-            plugin_config = self.update()
+            self.update()
 
         if not self.validate(plugin_config):
             raise InvalidConfigError
@@ -90,12 +90,12 @@ class BasePluginConfig(ABC):
             return
 
         palm_config = yaml.load(self.config_path.read_text(), Loader=yaml.FullLoader)
-        if not 'plugin_config' in palm_config.keys():
-            palm_config['plugin_config'] = {}
+        if not "plugin_config" in palm_config.keys():
+            palm_config["plugin_config"] = {}
 
         if not self.validate(config):
             click.secho("Invalid config, not writing to config file", fg="red")
             raise InvalidConfigError
 
-        palm_config['plugin_config'][self.plugin_name] = config
+        palm_config["plugin_config"][self.plugin_name] = config
         self.config_path.write_text(yaml.dump(palm_config))


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [X] All new and existing tests pass locally (`palm test`)
- [X] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

There was a bug! The setter method returns a dict but the `update` method which calls the setter returns a boolean. In `validate`, we were assigning the output of `update` as if it were the setter, but we don't need to do that (and shouldn't!) because it overwrites the config dict locally in the method. TypeError 🫠

Also, some lint fixes.

## Does this close any currently open issues?
…

## Any other comments?
…

## Where has this been tested?

**Operating System:** Mac OS Monterey

**Platform:** …

**Target Platform:** …
