### PR TITLE
[BUGFIX] plugin.update returning boolean, needs config object.

### DIFF
--- a/palm/plugins/core/commands/cmd_plugin.py
+++ b/palm/plugins/core/commands/cmd_plugin.py
@@ -134,7 +134,7 @@ def configure(environment, name: Optional[str]):
         click.secho(f"Plugin {name} not installed in this project", fg="red")
         return
 
-    success = plugin.config.update()
+    success, _ = plugin.config.update()
     if success:
         click.secho(f"Plugin {plugin.name} configured successfully", fg="green")
     else:

--- a/tests/unit/test_plugin_config.py
+++ b/tests/unit/test_plugin_config.py
@@ -44,14 +44,18 @@ def test_get_config(mock_plugin_config, tmp_path, monkeypatch):
 
     assert config.get() == {"value": "foo"}
 
+
 @pytest.mark.parametrize("config", [{"value": "foo"}])
-def test_update_config_returns_success_and_config(mock_plugin_config, tmp_path, monkeypatch):
+def test_update_config_returns_success_and_config(
+    mock_plugin_config, tmp_path, monkeypatch
+):
     config = mock_plugin_config
     config_path = tmp_path / "config.yaml"
     config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
     monkeypatch.setattr(config, "config_path", config_path)
 
     assert config.update() == (True, {"value": "foo"})
+
 
 @pytest.mark.parametrize("config", [{"value": "foo"}])
 def test_update_config_writes_to_file(mock_plugin_config, tmp_path, monkeypatch):
@@ -67,7 +71,9 @@ def test_update_config_writes_to_file(mock_plugin_config, tmp_path, monkeypatch)
 
 
 @pytest.mark.parametrize("config", [{}])
-def test_update_config_raises_for_invalid_config(mock_plugin_config, tmp_path, monkeypatch):
+def test_update_config_raises_for_invalid_config(
+    mock_plugin_config, tmp_path, monkeypatch
+):
     config = mock_plugin_config
     config_path = tmp_path / "config.yaml"
     config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
@@ -75,6 +81,7 @@ def test_update_config_raises_for_invalid_config(mock_plugin_config, tmp_path, m
 
     with pytest.raises(InvalidConfigError):
         config.update()
+
 
 @pytest.mark.parametrize("config", [{}])
 def test_read_config_with_update(mock_plugin_config, tmp_path, monkeypatch):

--- a/tests/unit/test_plugin_config.py
+++ b/tests/unit/test_plugin_config.py
@@ -1,5 +1,6 @@
 import pytest
 import yaml
+from unittest import mock
 
 from pathlib import Path
 from palm.palm_exceptions import InvalidConfigError
@@ -42,3 +43,58 @@ def test_get_config(mock_plugin_config, tmp_path, monkeypatch):
     monkeypatch.setattr(config, "config_path", config_path)
 
     assert config.get() == {"value": "foo"}
+
+@pytest.mark.parametrize("config", [{"value": "foo"}])
+def test_update_config_returns_success_and_config(mock_plugin_config, tmp_path, monkeypatch):
+    config = mock_plugin_config
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
+    monkeypatch.setattr(config, "config_path", config_path)
+
+    assert config.update() == (True, {"value": "foo"})
+
+@pytest.mark.parametrize("config", [{"value": "foo"}])
+def test_update_config_writes_to_file(mock_plugin_config, tmp_path, monkeypatch):
+    config = mock_plugin_config
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
+    monkeypatch.setattr(config, "config_path", config_path)
+
+    config.update()
+
+    config = yaml.safe_load(config_path.read_text())
+    assert config["plugin_config"]["test"]["value"] == "foo"
+
+
+@pytest.mark.parametrize("config", [{}])
+def test_update_config_raises_for_invalid_config(mock_plugin_config, tmp_path, monkeypatch):
+    config = mock_plugin_config
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
+    monkeypatch.setattr(config, "config_path", config_path)
+
+    with pytest.raises(InvalidConfigError):
+        config.update()
+
+@pytest.mark.parametrize("config", [{}])
+def test_read_config_with_update(mock_plugin_config, tmp_path, monkeypatch):
+    config = mock_plugin_config
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({'image_name': 'palm-test'}))
+    monkeypatch.setattr(config, "config_path", config_path)
+    monkeypatch.setattr(config, "update", lambda: (True, {"value": "bar"}))
+
+    assert config._read() == {"value": "bar"}
+
+
+@pytest.mark.parametrize("config", [{}])
+def test_read_config_existing(mock_plugin_config, tmp_path, monkeypatch):
+    config = mock_plugin_config
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({'plugin_config': {'test': {'value': 'foo'}}}))
+    monkeypatch.setattr(config, "config_path", config_path)
+    m = mock.Mock()
+    monkeypatch.setattr(config, "set", m)
+
+    assert config._read() == {"value": "foo"}
+    assert m.called == False


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

    Fix issue with plugin.update returning a only
    boolean, we need the config in the _read() function

    This was the result of a last minute refactor and inadequate testing.

    Added test coverage to prevent errors around this in the future

## Does this close any currently open issues?

[PR #93](https://github.com/palmetto/palm-cli/pull/93)

## Any other comments?

This solution is preferable as it prevents a different error where the config would not be updated on first write.

## Where has this been tested?

**Operating System:** macOS

**Platform:** Python3.9