### PR TITLE
Update Install With Generic Drop-In Instructions

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,11 +59,11 @@ To verify that the installation was successful, run ``palm --version``.
   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
 
 you will need to add ``'/Users/yourname/Library/Python/3.x/bin'`` to your path for
-``palm`` to work. 
+``palm`` to work.
 
 This command will work for bash, zsh and fsh shells:
 
-``export PALM_INSTALL_LIB_AT=$(python3 --version | sed -e "s/\(Python 3\.\)\([0-9]\)\.\([0-9]\)/3.\2/") && echo "\nexport PATH=$PATH:$HOME/Library/Python/${PALM_INSTALL_LIB_AT}/bin\n" | tee -a ~/.zprofile ~/.bashrc ~/.fshrc``
+``export PALM_INSTALL_LIB_AT=$(python3 --version | sed -e "s/\(Python 3\.\)\([0-9]*\)\.\([0-9]*\)/3.\2/") && echo "\nexport PATH=$PATH:$HOME/Library/Python/${PALM_INSTALL_LIB_AT}/bin\n" | tee -a ~/.zprofile ~/.bashrc ~/.fshrc``
 
 
 Configuration

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -55,16 +55,16 @@ To verify that the installation was successful, run ``palm --version``.
 
 **note for mac users**: if you get this warning::
 
-  WARNING: The script palm is installed in '/Users/yourname/Library/Python/3.8/bin' which is not on PATH.
+  WARNING: The script palm is installed in '~/Library/Python/3.x/bin' which is not on PATH.
   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
 
-you will need to add ``'/Users/yourname/Library/Python/3.8/bin'`` to your path for
-``palm`` to work. You can do that with one of these commands (depending on your
-shell of choice):
+you will need to add ``'/Users/yourname/Library/Python/3.x/bin'`` to your path for
+``palm`` to work. 
 
-- zsh: ``echo "\nexport PATH=$PATH:/Users/yourname/Library/Python/3.8/bin\n" >> ~/.zprofile``
-- bash: ``echo "export PATH=$PATH:/Users/yourname/Library/Python/3.8/bin" >> ~/.bashrc``
-- fsh: ``echo "setenv PATH $PATH:/Users/yourname/Library/Python/3.8/bin" >> ~/.fshrc``
+This command will work for bash, zsh and fsh shells:
+
+``export PALM_INSTALL_LIB_AT=$(python3 --version | sed -e "s/\(Python 3\.\)\([0-9]\)\.\([0-9]\)/3.\2/") && echo "\nexport PATH=$PATH:$HOME/Library/Python/${PALM_INSTALL_LIB_AT}/bin\n" | tee -a ~/.zprofile ~/.bashrc ~/.fshrc``
+
 
 Configuration
 =============


### PR DESCRIPTION
This makes the "add to path" command drop-and-go for mac/nix users 🚀

- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change
nope no breaking stuff

## What does this implement/fix? Explain your changes.

This makes the "add to path" section of the docs a bit more agnostic - uses whatever python3 version is the current system default, and covers all 3 popular shells.

## Does this close any currently open issues?
nope I don't think so

## Any other comments?
This still doesn't help windoze folks, probably need to add that as well at some point to make the install docs super helpful.

## Where has this been tested?

**Operating System:** Mac OS (M1) Ventura 13.1 (22C65)

**Platform:** Bash shell

**Target Platform:** Bash, Zsh, Fsh
