### PR TITLE
[FEATURE] Support modern docker compose

### DIFF
--- a/.palm/cmd_docs.py
+++ b/.palm/cmd_docs.py
@@ -13,7 +13,7 @@ def cli(environment):
 
     click.echo(f"Launching palm-cli readthedocs at {CODE_DOCS_URI}...")
     exit_code, out, err = environment.run_on_host(
-        "docker-compose run -d --rm --service-ports palm_docs"
+        "docker compose run -d --rm --service-ports palm_docs"
     )
     if exit_code > 0:
         if "port is already allocated" in err:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ and you have global plugins installed!
 ### Fixed
 
 - Fixed a path issue for windows users when using code_gen or palm init
-- Fixes a potential security vulnerability when upgrading plugins via 
+- Fixes a potential security vulnerability when upgrading plugins via
 `palm plugin update`
 - Fixes a number of other small issues detected by CodeQL static anlysis
 
@@ -103,14 +103,14 @@ Python Version Support:
 - **Global config & Global plugins** Palm now supports installing plugins globally!
 After updating to palm 2.2.0, the first time you run `palm ...` a new global config
 will be created at `~/.palm/config.yaml`, you can add plugins to this config to
-make them available to all of your repositories! This feature was developed to 
+make them available to all of your repositories! This feature was developed to
 support a Palmetto internal `palm-workflow` plugin, which is used to manage our
 dev workflow in Trello.
 
 ### Fixed
 
 - **pygit2 version pin adjusted**: The upper version pin on pygit2 was removed to resolve an error
-installing palm on newer versions of MacOS. Note that libgit2 is still required, 
+installing palm on newer versions of MacOS. Note that libgit2 is still required,
 per the requirements of pygit2. A future version will introduce checking for libgit2
 and more friendly error messaging.
 - **Upgraded jinja**: We were previously using an unsupported version of Jinja which was using
@@ -121,7 +121,7 @@ installing palm. We upgraded to the latest version of jinja to resolve this issu
 
 ### Fixed
 
-- Resolve a template issue when running `palm plugin new` 
+- Resolve a template issue when running `palm plugin new`
 
 ### Changed
 
@@ -132,7 +132,7 @@ argument, this is a cleaner API for interacting with the Palm.Environment class
 
 ## [2.1.0] - 2021-12-01
 
-Our first minor release on v2 includes containerization, support for older Python versions, 
+Our first minor release on v2 includes containerization, support for older Python versions,
 and added logo and brand assets!
 
 ### Added
@@ -141,7 +141,7 @@ and added logo and brand assets!
 - **Shell**: NEW command to shell into the project container and execute arbitrary commands
 - **Plugin generator**: NEW command to generate the boilerplate code for writing a new plugin
 - **Excluded commands**: Added the ability to exclude/disable `palm` commands from a project's config
-- **`run_on_host`**: Added a new function, `ctx.obj.run_on_host`, to assist with developing new commands 
+- **`run_on_host`**: Added a new function, `ctx.obj.run_on_host`, to assist with developing new commands
 to run on your local machine, standardizing the interface around Python's `subprocess` with platform
 and version agnostic support (well, version agnostic >= 3.6.9).
 - **Logo/Branding**: We have a logo!! It is 90's retro and it is cool. Also added branding guidelines
@@ -174,7 +174,7 @@ with a changelog entry!
 All commands in Palm are made available by one of several plugins. The core
 plugin and repo plugin are part of the Palm-cli repository and provide global commands
 as well as commands defined within the project's .palm directory. Additional plugins
-such as palm-dbt can be installed on the user's machine and configured for use 
+such as palm-dbt can be installed on the user's machine and configured for use
 on a per-project basis. See the plugin section of the docs for more information
 - **Palm config** Palm now reads a config.yaml file from the current project's .palm
 directory. This configuration enables the plugin architecture and allows us more

--- a/docs/source/commands.rst
+++ b/docs/source/commands.rst
@@ -146,14 +146,14 @@ That could look something like this:
   @click.pass_obj
   def cli(environment):
       """Starts the container as daemon, watches the logs, then exits"""
-      environment.run_on_host("docker-compose run -d super_slow_starting_django_app",
+      environment.run_on_host("docker compose run -d super_slow_starting_django_app",
                            check=True)
 
       ## this is where we watch, pseudo-blocking
       building_logs = str()
       while "Starting local webserver via runserver on port 8080..." \
         not in building_logs:
-          logs, _, _ = environment.run_on_host("docker-compose logs static_app")
+          logs, _, _ = environment.run_on_host("docker compose logs static_app")
             if logs != building_logs:
                 building_logs = logs
                 click.echo(logs)

--- a/docs/source/introduction/examples.rst
+++ b/docs/source/introduction/examples.rst
@@ -6,35 +6,35 @@ Onboarding
 ==========
 
 Setting up a new full-time employee for success is the most straightforward example
-of how palm can immediately impact productivity. 
+of how palm can immediately impact productivity.
 
-Let’s say today is your first day as an Analytics Engineer for a shop that uses dbt. 
-Let’s also say this shop also uses palm, with the palm-dbt plugin. 
+Let’s say today is your first day as an Analytics Engineer for a shop that uses dbt.
+Let’s also say this shop also uses palm, with the palm-dbt plugin.
 
 Day one goes something like this:
 
 1. You install Docker, git, your text editor and palm
 2. You get all your secrets assigned and SSH set up with github
-3. You clone the working dbt repo and run `palm` from root. You see something like this: 
+3. You clone the working dbt repo and run `palm` from root. You see something like this:
 
 .. code:: bash
 
    $ palm
-   Commands: 
+   Commands:
    run          executes dbt run in the namespaced schema for your branch
-   cycle        executes dbt run, test, run, test 
+   cycle        executes dbt run, test, run, test
    cleanup      cleans the local and removes all remote artifacts from testing in the data warehouse
-  
-   # compile, test etc.
-  
 
-4. Using the gitflow naming pattern of ``<branch-type>/<ticket-key>/<description>`` you check out your first work ticket: 
+   # compile, test etc.
+
+
+4. Using the gitflow naming pattern of ``<branch-type>/<ticket-key>/<description>`` you check out your first work ticket:
 
 .. code:: bash
 
    $ git checkout -b feature/DATA-204/fix-sales-column-name
 
-5. You run ``palm cycle`` as a baseline: 
+5. You run ``palm cycle`` as a baseline:
 
 .. code:: bash
 
@@ -43,52 +43,52 @@ Day one goes something like this:
    against schema `TEST.feature_data_204_fix_sales_column_name`
    ## ... dbt run details here
    success. dbt completed with 96 models and 144 tests, run 2x each in 120 seconds.
-   cleaning up the remote target... 
-   clean. 
+   cleaning up the remote target...
+   clean.
 
-Your development work executes in a sophisticated environment with automated namespacing, 
-automated cleanup, and idempotency testing. 
+Your development work executes in a sophisticated environment with automated namespacing,
+automated cleanup, and idempotency testing.
 
 There was near-zero learning curve for you, no tribal knowledge transfer needed, and you were able to start adding value hours into your first day on the team.
 
 
 Cross Platform
 ==============
-Palm is written in Python, giving you the interoperability of a higher level programming language, 
-and relies heavily on the ``docker`` and ``docker-compose`` APIs to create OS-agnostic 
+Palm is written in Python, giving you the interoperability of a higher level programming language,
+and relies heavily on the ``docker`` and ``docker compose`` APIs to create OS-agnostic
 development environments. Leveraging palm's native `run_in_docker` commands, you can run the same code
-on any system and get the same results. 
+on any system and get the same results.
 
 
 Context Switching
 =================
 
-Possibly the most powerful long-term impact of palm is the way it removes internal barriers between software workflows. 
-Let’s say you are a developer at a modern e-commerce platform. The ecom site is powered by Ruby on Rails. The highly-trafficked content site uses WordPress. Your virtual dressing room software is built on Rocket, and the whole of the infrastructure is managed by Terraform. 
-A new feature is rolling out that uses the virtual dressing room. First, you update the Rocket application to enable the feature. You start by reviewing your options (it’s been a minute since you have worked in this repo): 
+Possibly the most powerful long-term impact of palm is the way it removes internal barriers between software workflows.
+Let’s say you are a developer at a modern e-commerce platform. The ecom site is powered by Ruby on Rails. The highly-trafficked content site uses WordPress. Your virtual dressing room software is built on Rocket, and the whole of the infrastructure is managed by Terraform.
+A new feature is rolling out that uses the virtual dressing room. First, you update the Rocket application to enable the feature. You start by reviewing your options (it’s been a minute since you have worked in this repo):
 
-.. code:: bash 
+.. code:: bash
 
-   $ cd ~/Repos/virtual_dressing_room && palm 
+   $ cd ~/Repos/virtual_dressing_room && palm
    Commands:
    launch     launches the vdr as a request server (daemon)
    request    starts an interactive request terminal to to the local server
    test          runs all the non-destructive tests locally
    launch-test    runs tests that will destroy the UAT environment, should only be run before a deployment
 
-Once the Rocket code is updated and merged, you launch the feature on the ecom site. 
+Once the Rocket code is updated and merged, you launch the feature on the ecom site.
 
-.. code:: bash 
+.. code:: bash
 
    $ cd ~/Repos/ecommerce_site && palm up
 
 You make your changes, testing with ``palm test``. The same happens with the WordPress and your infra work.
- 
-**Here is where it gets interesting!** 
+
+**Here is where it gets interesting!**
 
 You get a panicked call from the finance team.
 
-It appears the only Data Engineer is on vacation and they forgot a CCPA request due today! 
+It appears the only Data Engineer is on vacation and they forgot a CCPA request due today!
 You quickly clone the data team’s ``ccpa_privacy`` repo, and do this:
 
 .. code:: bash
@@ -96,19 +96,19 @@ You quickly clone the data team’s ``ccpa_privacy`` repo, and do this:
    $ cd ~/Repos/ccpa_privacy && palm
    Commands:
    delete       deletes (or obfuscates) a user by email address. Enforces financial retention per our privacy policy.
-   report       generates a right-of-portability report of the data we have on a user by email address. non-destructive. 
+   report       generates a right-of-portability report of the data we have on a user by email address. non-destructive.
 
-   $ palm report --help 
-     Generates a json report of all the found data relating to a given email address. 
+   $ palm report --help
+     Generates a json report of all the found data relating to a given email address.
 
      Args: email-address: the email to look up
-   
-   $ palm report dave@requestedprivacy.com
-   Generating report… 
-   Report done. Saved to ~/Documents/privacy_report_123.json 
 
-When an organization adopts palm, moving from one codebase to another becomes fluid, and without hard context switches. 
-Developers can confidently pick up and start working with any code, anywhere in the organization - including code they have never seen before. 
+   $ palm report dave@requestedprivacy.com
+   Generating report…
+   Report done. Saved to ~/Documents/privacy_report_123.json
+
+When an organization adopts palm, moving from one codebase to another becomes fluid, and without hard context switches.
+Developers can confidently pick up and start working with any code, anywhere in the organization - including code they have never seen before.
 
 
 

--- a/docs/source/introduction/viewpoint.rst
+++ b/docs/source/introduction/viewpoint.rst
@@ -2,12 +2,15 @@
 Wait. Why Do My CLIs need a CLI?
 ================================
 
-For a seasoned Engineer, the idea of wrapping public software interfaces in an abstraction layer will probably set off some warning bells. Admittedly, at first glance palm can appear to add unnecessary complexity and “magic” to an already polished API. For example, bringing up a docker-compose service stack:
+For a seasoned Engineer, the idea of wrapping public software interfaces in an
+abstraction layer will probably set off some warning bells. Admittedly, at first
+glance palm can appear to add unnecessary complexity and “magic” to an already
+polished API. For example, bringing up a docker compose service stack:
 
 .. code:: bash
-    
-    # via native docker-compose
-    $ docker-compose up -d 
+
+    # via native docker compose
+    $ docker compose up -d
     Creating network my-project… done
 
     # via palm
@@ -15,30 +18,31 @@ For a seasoned Engineer, the idea of wrapping public software interfaces in an a
     Creating network my-project… done
 
 
-In this case, it is hard to see the argument for palm’s usefulness. But modern software development rarely stays that simple for long. 
-Let’s look at a real-world use case where we want to run tests on the Django webapp portion of our monorepo. 
+In this case, it is hard to see the argument for palm’s usefulness. But modern
+software development rarely stays that simple for long. Let’s look at a real-world
+use case where we want to run tests on the Django webapp portion of our monorepo.
 In this case the stack is down and the needed port is allocated by an orphan container.
 
-.. code:: bash 
+.. code:: bash
 
-   # via native bash + docker-compose
-   $ docker-compose exec --rm --service-ports my_app /bin/bash -c “pytest webapp/tests/webapp”
+   # via native bash + docker compose
+   $ docker compose exec --rm --service-ports my_app /bin/bash -c “pytest webapp/tests/webapp”
    ERROR: No such service: my_app
-   
-   $ docker-compose up -d 
+
+   $ docker compose up -d
    ERROR: Bind for 0.0.0.0:8080 failed: port is already allocated
-   
+
    $ docker ps
    CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
    I98ds8sd90gsd    django1    /bin/bash        2 days ago  running
-   
+
    $ docker kill I98ds8sd90gsd
    I98ds8sd90gsd
-   
-   $ docker-compose up -d 
+
+   $ docker compose up -d
    Creating network my-project… done
 
-   $ docker-compose exec --rm --service-ports my_app /bin/bash -c “pytest webapp/tests/webapp”
+   $ docker compose exec --rm --service-ports my_app /bin/bash -c “pytest webapp/tests/webapp”
    Running 84 tests via pytest…
 
    # same thing, via palm
@@ -49,7 +53,13 @@ In this case the stack is down and the needed port is allocated by an orphan con
    Starting compose… Started.
    Running 84 tests via pytest…
 
-Suddenly, palm starts to make a lot of sense. The abstraction layer that palm provides allows you to architect simplicity and consistency into your development environments across languages, frameworks, and infrastructure designs. You decide what each command does, designing the workflow interface for each repo. A simple single-container Jekyll app, and a complex multi-cloud microservices ecosystem, each implemented by different teams with completely different skills, can share a common interface. 
+Suddenly, palm starts to make a lot of sense. The abstraction layer that palm
+provides allows you to architect simplicity and consistency into your development
+environments across languages, frameworks, and infrastructure designs. You decide
+what each command does, designing the workflow interface for each repo. A simple
+single-container Jekyll app, and a complex multi-cloud microservices ecosystem,
+each implemented by different teams with completely different skills, can share
+a common interface.
 
 Palm Is Working Software
 ====================
@@ -59,45 +69,45 @@ Palm Is Working Software
 
         ~ `Agile Manifesto <https://agilemanifesto.org/#:~:text=processes%20and%20tools-,Working%20software,-over%20comprehensive%20documentation>`_
 
-A core concept in quality programming is `Self-documenting code <https://en.wikipedia.org/wiki/Self-documenting_code>`_. 
+A core concept in quality programming is `Self-documenting code <https://en.wikipedia.org/wiki/Self-documenting_code>`_.
 Most seasoned Engineers would cringe if they came across a function like this:
 
 .. code:: javascript
-   
+
    /* Function for determining customer balance.
-       This function takes the current known balance, 
+       This function takes the current known balance,
        queries the bank api with the customer account,
        then if the api returns a new balance it applies it to… (etc etc)
-   */ 
+   */
    function customerBalance(custId){
-      // awful code goes here 
+      // awful code goes here
    }
 
-And yet, the first instinct when engineering a development environment is 
-often to generate reams of stagnant documentation! 
-For example, let’s say a team of Developers randomly suffer from this error: 
+And yet, the first instinct when engineering a development environment is
+often to generate reams of stagnant documentation!
+For example, let’s say a team of Developers randomly suffer from this error:
 
 .. code:: bash
 
-   $ docker-compose up -d 
+   $ docker compose up -d
    ERROR: unable to read file app/conf: file does not exist or access denied
 
 After hours of painful debugging, it is discovered that this is not a permission or mounting issue,
-but that docker is actually out of memory. 
-The fix is to clean up the docker environment. 
-Convention is to add this find to the project Readme.md, like this: 
+but that docker is actually out of memory.
+The fix is to clean up the docker environment.
+Convention is to add this find to the project Readme.md, like this:
 
-.. code::  
+.. code::
 
    #Readme.md
-      
-   ## Troubleshooting
-   **“ERROR: unable to read file app/conf: file does not exist or access denied”** : 
-   your docker environment may be out of memory. Start by running `docker rm -f $(docker ps -qa)` … 
 
-But what if, instead of writing docs - docs the Developers will likely forget to check, 
-with steps that will need to be methodically replicated -  
-what if the fix was automated? Enter palm. 
+   ## Troubleshooting
+   **“ERROR: unable to read file app/conf: file does not exist or access denied”** :
+   your docker environment may be out of memory. Start by running `docker rm -f $(docker ps -qa)` …
+
+But what if, instead of writing docs - docs the Developers will likely forget to check,
+with steps that will need to be methodically replicated -
+what if the fix was automated? Enter palm.
 
 .. code:: python
 
@@ -113,20 +123,20 @@ what if the fix was automated? Enter palm.
            red_echo(“Docker may be out of memory, cleaning up first…”)
            environment.docker_full_clean()
            environment.docker_up(bubble_error=True)
-           green_echo(“Docker stack started.”)       
-	
+           green_echo(“Docker stack started.”)
+
 Now and forever, your developers will see this when they run out of memory:
 
 .. code:: bash
 
-   $ palm up 
+   $ palm up
    Starting docker stack…
    Docker may be out of memory, cleaning up first...
    Docker stack started.
 
-Of course this solution is very basic. In a real implementation we might want to 
-check that the file exists and has the correct permissions, prompt the developer before nuking the docker environment etc. 
+Of course this solution is very basic. In a real implementation we might want to
+check that the file exists and has the correct permissions, prompt the developer before nuking the docker environment etc.
 
 **As Engineers, we preach the value of automation and scoff at repetitive, error-prone manual tasks.
-Palm is a way for us to practice what we preach.** 
+Palm is a way for us to practice what we preach.**
 

--- a/palm/cli.py
+++ b/palm/cli.py
@@ -133,10 +133,6 @@ def required_dependencies_ready():
             "Docker is not installed, please install it first",
         ),
         (
-            "which docker-compose || where docker-compose",
-            "Docker Compose is not installed, please install it first",
-        ),
-        (
             "docker ps",
             "Docker is not running, please start it first",
         ),

--- a/palm/environment.py
+++ b/palm/environment.py
@@ -32,7 +32,7 @@ class Environment:
         """
         click.secho(f"Executing command `{cmd}` in compose...", fg="yellow")
 
-        docker_cmd = ["docker-compose run --service-ports --rm"]
+        docker_cmd = ["docker compose run --service-ports --rm"]
         docker_cmd.extend(self._build_env_vars(env_vars))
         docker_cmd.append(self.palm.image_name)
         if no_bin_bash:

--- a/palm/plugins/core/commands/cmd_build.py
+++ b/palm/plugins/core/commands/cmd_build.py
@@ -6,4 +6,4 @@ import click
 @click.command("build")
 def cli():
     """Rebuilds the image for the current working directory"""
-    subprocess.run(["docker-compose", "build"], check=True)
+    subprocess.run(["docker", "compose", "build"], check=True)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [ ] Consider adding a unit test if your PR resolves an issue.
- [ ] All new and existing tests pass locally (`palm test`)
- [ ] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [x] Check if this pull request introduces a breaking change

This is technically a breaking change, but since docker has been shipping with compose v2 for over a year and is approaching end of support (next month) I feel ok about releasing this as a minor version

## What does this implement/fix? Explain your changes.

Update palm to use `docker compose` instead of `docker-compose`. 

## Does this close any currently open issues?

Resolves: #97

## Where has this been tested?

**Operating System:** MacOS

**Platform:** Docker version 23.0.5
