### PR TITLE
Abstract run_in_docker to a utility function

### DIFF
--- a/palm/environment.py
+++ b/palm/environment.py
@@ -6,7 +6,7 @@ import click
 from pydantic import BaseModel
 
 from palm.plugin_manager import PluginManager
-from palm.utils import run_on_host
+from palm.utils import run_on_host, run_in_docker
 
 from .code_generator import CodeGenerator
 from .palm_config import PalmConfig
@@ -24,26 +24,8 @@ class Environment:
         env_vars: Optional[dict] = {},
         no_bin_bash: Optional[bool] = False,
     ) -> Tuple[bool, str]:
-        """Shells out and runs the cmd in docker
-
-        Args:
-            cmd (str): The command you want to run
-            env_vars (Optional[dict], optional): Dict of env vars to pass to the docker container.
-        """
-        click.secho(f"Executing command `{cmd}` in compose...", fg="yellow")
-
-        docker_cmd = ["docker compose run --service-ports --rm"]
-        docker_cmd.extend(self._build_env_vars(env_vars))
-        docker_cmd.append(self.palm.image_name)
-        if no_bin_bash:
-            docker_cmd.append(cmd)
-        else:
-            docker_cmd.append(f'/bin/bash -c "{cmd}" ')
-
-        ex_code, _, _ = run_on_host(" ".join(docker_cmd))
-        if ex_code == 0:
-            return (True, "Success! Palm completed with exit code 0")
-        return (False, f"Fail! Palm exited with code {ex_code}")
+        env_vars_list = self._build_env_vars(env_vars)
+        return run_in_docker(cmd, self.palm.image_name, env_vars_list, no_bin_bash)
 
     def run_in_shell(self, cmd: str, env_vars: Optional[dict] = {}):
         """deprecated - use run_in_docker"""

--- a/palm/environment.py
+++ b/palm/environment.py
@@ -23,9 +23,16 @@ class Environment:
         cmd: str,
         env_vars: Optional[dict] = {},
         no_bin_bash: Optional[bool] = False,
+        silent: Optional[bool] = False,
     ) -> Tuple[bool, str]:
         env_vars_list = self._build_env_vars(env_vars)
-        return run_in_docker(cmd, self.palm.image_name, env_vars_list, no_bin_bash)
+        return run_in_docker(
+            cmd,
+            self.palm.image_name,
+            env_vars_list,
+            no_bin_bash,
+            silent
+        )
 
     def run_in_shell(self, cmd: str, env_vars: Optional[dict] = {}):
         """deprecated - use run_in_docker"""

--- a/palm/environment.py
+++ b/palm/environment.py
@@ -27,11 +27,7 @@ class Environment:
     ) -> Tuple[bool, str]:
         env_vars_list = self._build_env_vars(env_vars)
         return run_in_docker(
-            cmd,
-            self.palm.image_name,
-            env_vars_list,
-            no_bin_bash,
-            silent
+            cmd, self.palm.image_name, env_vars_list, no_bin_bash, silent
         )
 
     def run_in_shell(self, cmd: str, env_vars: Optional[dict] = {}):

--- a/palm/plugins/base_plugin_config.py
+++ b/palm/plugins/base_plugin_config.py
@@ -19,8 +19,7 @@ class BasePluginConfig(ABC):
         """Setter for plugin config
 
         This method should be implemented by the plugin to set the config
-        for the plugin. It should return True if the config was set successfully,
-        and False if it was not.
+        for the plugin. It should return a dict of the config that was set.
 
         Returns:
             dict: The config that was set

--- a/palm/utils.py
+++ b/palm/utils.py
@@ -63,6 +63,7 @@ def run_in_docker(
     env_vars: Optional[List[str]] = [],
     no_bin_bash: Optional[bool] = False,
     capture_output: Optional[bool] = False,
+    silent: Optional[bool] = False,
 ) -> Tuple[bool, str]:
     """Shells out and runs the cmd in docker
 
@@ -70,7 +71,8 @@ def run_in_docker(
         cmd (str): The command you want to run
         env_vars (Optional[dict], optional): Dict of env vars to pass to the docker container.
     """
-    click.secho(f"Executing command `{cmd}` in compose...", fg="yellow")
+    if not silent:
+        click.secho(f"Executing command `{cmd}` in compose...", fg="yellow")
 
     docker_cmd = ["docker compose run --service-ports --rm"]
     docker_cmd.extend(env_vars)

--- a/palm/utils.py
+++ b/palm/utils.py
@@ -62,6 +62,7 @@ def run_in_docker(
     image_name: str,
     env_vars: Optional[List[str]] = [],
     no_bin_bash: Optional[bool] = False,
+    capture_output: Optional[bool] = False,
 ) -> Tuple[bool, str]:
     """Shells out and runs the cmd in docker
 
@@ -79,7 +80,12 @@ def run_in_docker(
     else:
         docker_cmd.append(f'/bin/bash -c "{cmd}" ')
 
-    ex_code, _, _ = run_on_host(" ".join(docker_cmd))
+    ex_code, std_out, std_err = run_on_host(" ".join(docker_cmd), False, capture_output)
+    if capture_output:
+        if ex_code == 0:
+            return (True, std_out)
+        return (False, std_err)
+
     if ex_code == 0:
         return (True, "Success! Palm completed with exit code 0")
     return (False, f"Fail! Palm exited with code {ex_code}")

--- a/palm/utils.py
+++ b/palm/utils.py
@@ -1,6 +1,8 @@
 import subprocess
 from sys import version_info
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
+
+import click
 
 
 class UnsupportedVersion(Exception):
@@ -53,3 +55,31 @@ def run_on_host(
         completed.stdout.decode("utf-8") if completed.stdout else "",
         completed.stderr.decode("utf-8") if completed.stderr else "",
     )
+
+
+def run_in_docker(
+    cmd: str,
+    image_name: str,
+    env_vars: Optional[List[str]] = [],
+    no_bin_bash: Optional[bool] = False,
+) -> Tuple[bool, str]:
+    """Shells out and runs the cmd in docker
+
+    Args:
+        cmd (str): The command you want to run
+        env_vars (Optional[dict], optional): Dict of env vars to pass to the docker container.
+    """
+    click.secho(f"Executing command `{cmd}` in compose...", fg="yellow")
+
+    docker_cmd = ["docker compose run --service-ports --rm"]
+    docker_cmd.extend(env_vars)
+    docker_cmd.append(image_name)
+    if no_bin_bash:
+        docker_cmd.append(cmd)
+    else:
+        docker_cmd.append(f'/bin/bash -c "{cmd}" ')
+
+    ex_code, _, _ = run_on_host(" ".join(docker_cmd))
+    if ex_code == 0:
+        return (True, "Success! Palm completed with exit code 0")
+    return (False, f"Fail! Palm exited with code {ex_code}")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below. -->
## Pull request checklist

Before submitting your PR, please review the following checklist:

- [x] Consider adding a unit test if your PR resolves an issue.
- [x] All new and existing tests pass locally (`palm test`)
- [x] Lint (`palm lint`) has passed locally and any fixes were made for failures
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Breaking changes

- [ ] Check if this pull request introduces a breaking change

## What does this implement/fix? Explain your changes.

This will allow plugins to execute commands in docker during setup. We need this to reliably detect which dbt version a given project is using.

There is no functional change here, just a new abstraction to enable a change elsewhere.

## Does this close any currently open issues?

Not directly, it's a step towards being able to resolve an open issue in palm-dbt

## Where has this been tested?

MacOS + Docker v24
Tested with a dbt project using palm-dbt
Tested with a non-dbt project.
